### PR TITLE
added project entity with project status constants

### DIFF
--- a/src/main/java/com/devtracker/DevTracker/model/Issue.java
+++ b/src/main/java/com/devtracker/DevTracker/model/Issue.java
@@ -1,5 +1,8 @@
 package com.devtracker.DevTracker.model;
 
+import com.devtracker.DevTracker.model.enums.IssueType;
+import com.devtracker.DevTracker.model.enums.Priority;
+import com.devtracker.DevTracker.model.enums.Status;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/devtracker/DevTracker/model/Project.java
+++ b/src/main/java/com/devtracker/DevTracker/model/Project.java
@@ -1,0 +1,52 @@
+package com.devtracker.DevTracker.model;
+
+import com.devtracker.DevTracker.model.enums.ProjectStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "project")
+public class Project {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int projectId;
+
+    private String projectName;
+    private String projectDesc;
+
+    private Date createdAt;
+
+    private Date deadline;
+
+    @ManyToOne
+    @JoinColumn(name = "team_lead_id")
+    private User teamLead;
+
+    @ManyToMany
+    @JoinTable(
+            name = "project_members",
+            joinColumns = @JoinColumn(name = "project_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private List<User> teamMembers;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectStatus status;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Issue> issues;
+
+
+
+    // Getters and setters
+}

--- a/src/main/java/com/devtracker/DevTracker/model/enums/ProjectStatus.java
+++ b/src/main/java/com/devtracker/DevTracker/model/enums/ProjectStatus.java
@@ -1,0 +1,8 @@
+package com.devtracker.DevTracker.model.enums;
+
+public enum ProjectStatus {
+    ACTIVE,
+    COMPLETED,
+    ON_HOLD
+}
+


### PR DESCRIPTION
I have implemented a project management system called DevTracker, which includes two main entities: User and Project. The User entity handles user-related information such as ID, name, email, password, and position. The Project entity manages project details including ID, description, creation date, deadline, team lead (as a foreign key to User), team members (as a list of Users), and project status using an enum (ACTIVE, COMPLETED, ON_HOLD). Relationships between users and projects are modeled using JPA annotations with @ManyToOne and @ManyToMany mappings. This setup allows efficient assignment, tracking, and management of projects and team roles within the system.